### PR TITLE
Issue #17: Align what gets checked during sessions

### DIFF
--- a/src/discord-oauth/controllers/auth/auth.controller.ts
+++ b/src/discord-oauth/controllers/auth/auth.controller.ts
@@ -1,7 +1,6 @@
-import { Body, Controller, Get, Post, Req, Res, Session } from '@nestjs/common'
+import { Body, Controller, Get, Post, Req, Res } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { Request, Response } from 'express'
-import { SessionData } from 'express-session'
 import {
   AccessToken,
   OAuthHelperService,
@@ -113,11 +112,8 @@ export class AuthController {
   })
   @PublicRoute()
   @Post()
-  async exchangeAccessCode(
-    @Body() { code }: CodePayload,
-    @Session() session: SessionData,
-  ) {
+  async exchangeAccessCode(@Body() { code }: CodePayload, @Req() req: Request) {
     const authToken = await this.oauthHelper.exchangeAccessCode(code)
-    session.tokens = authToken
+    req.session.tokens = authToken
   }
 }

--- a/src/guards/session.guard.ts
+++ b/src/guards/session.guard.ts
@@ -31,6 +31,10 @@ export class SessionGuard implements CanActivate {
       return true
     }
 
+    /*
+     * If we just return false, Nest will throw 403.
+     * We want 401 for no sessions, so we have to throw it explicitly.
+     */
     throw new UnauthorizedException()
   }
 }

--- a/src/guards/session.guard.ts
+++ b/src/guards/session.guard.ts
@@ -1,7 +1,12 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
+import { Request } from 'express'
 import { Observable } from 'rxjs'
-import { DiscordOAuthTokens } from 'src/discord-oauth/types'
 
 export const IS_PUBLIC = 'IS_PUBLIC'
 
@@ -21,10 +26,11 @@ export class SessionGuard implements CanActivate {
       return true
     }
 
-    const req: { session: DiscordOAuthTokens } = context
-      .switchToHttp()
-      .getRequest()
+    const req = context.switchToHttp().getRequest<Request>()
+    if (req?.session?.tokens) {
+      return true
+    }
 
-    return !!req?.session?.refreshToken
+    throw new UnauthorizedException()
   }
 }


### PR DESCRIPTION
**Cause:**

When a session is established in the controller for the OAuth code exchange, the token gets stored in `session.tokens`.

However, the auth guard seems to check for `session.refreshTokens` instead.

**Fix:**

Make sure that it's checked in `session.tokens`.