### PR TITLE
Adhoc: Make the develop pipeline run for all MRs regardless of target

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ['develop-*']
   pull_request:
-    branches: ['develop-*']
+    # run on each MR regardless of target
 
 jobs:
   run-tests:


### PR DESCRIPTION
Prior to this MR, the pipeline only runs for MRs targeted to `develop-*`